### PR TITLE
Added '-' as illegal property name to CleanPropertyName

### DIFF
--- a/AppSettings.tt
+++ b/AppSettings.tt
@@ -72,7 +72,7 @@ namespace <#=namespaceName#>
     
     private string CleanPropertyName(string name)
     {
-        var regex = new System.Text.RegularExpressions.Regex(@"\! | \@ | \# | \$ | \% | \^ | \& | \* | \( | \) | \+ | \= | \< | \> | \, | \.  | \/ | \\ | \? | \| | \{ | \} | \[ | \] | \: | \; | \' | \"" | \` | \~", System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace);
+        var regex = new System.Text.RegularExpressions.Regex(@"\! | \@ | \# | \$ | \% | \^ | \& | \* | \( | \) | \+ | \= | \< | \> | \, | \.  | \/ | \\ | \? | \| | \{ | \} | \[ | \] | \: | \; | \' | \"" | \` | \~ | - ", System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace);
         return regex.Replace(name, "_");
     }
 


### PR DESCRIPTION
This resolves a issue whereby T4AppSettings would produce members which contain '-' which is an illegal character. Usually when happens using the `Serilog.Extras.AppSettings` package as per https://github.com/serilog/serilog/wiki/AppSettings

```
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings>
    <add key="serilog:minimum-level" value="Verbose" />
```

Would yield invalid output of:

```
    public static string serilog_minimum-level { get { return GetConfigSettingItem("serilog:minimum-level"); } }
```

Corrected output is now:

```
    public static string serilog_minimum_level { get { return GetConfigSettingItem("serilog:minimum-level"); } }
```

Please merge and push back up to NuGet.org - thanks.
